### PR TITLE
change react-queryt id to endpoint

### DIFF
--- a/app/javascript/components/tooltips/Tooltip.tsx
+++ b/app/javascript/components/tooltips/Tooltip.tsx
@@ -50,7 +50,7 @@ export const Tooltip = ({
   })
 
   const { isLoading, isError, htmlContent } = useTooltipContentQuery(
-    id,
+    contentEndpoint,
     contentEndpoint,
     showState != 'hidden' && showState != 'error'
   )


### PR DESCRIPTION
Currently, there is a collision occuring between tracks because how turbolinks works.
Turbolinks prevents react-query from being unloaded, so the cache is persisted, so using `basics` can cause a collision between different tracks with same-named concepts.